### PR TITLE
use `numpy.nanmean` by default

### DIFF
--- a/src/stpreview/downsample.py
+++ b/src/stpreview/downsample.py
@@ -33,7 +33,7 @@ def known_asdf_observatory(input: Path, known: list[str] = None) -> str:
 def downsample_asdf_by(
     input: Path,
     factor: Union[int, tuple[int, ...]],
-    func=numpy.mean,
+    func=numpy.nanmean,
     observatory: str = None,
 ) -> numpy.ndarray:
     """
@@ -69,7 +69,7 @@ def downsample_asdf_by(
 
 
 def downsample_asdf_to(
-    input: Path, shape: tuple[int, int], func=numpy.mean, observatory: str = None
+    input: Path, shape: tuple[int, int], func=numpy.nanmean, observatory: str = None
 ) -> numpy.ndarray:
     """
     attempt to downsample an ASDF image to (near) the specified resolution


### PR DESCRIPTION
as described in https://github.com/spacetelescope/romancal/pull/953#issuecomment-1792547228, using `numpy.nanmean` addresses the case where frames may have `NaN`