### PR TITLE
remove `typer` dependency by using builtin `argparse` instead, and reorder CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ options:
 
 ```
 ❯ uv run stpreview input.asdf output.png by --help
-usage: stpreview INPUT OUTPUT by [-h] factor [factor ...]
+usage: stpreview INPUT OUTPUT by [-h] FACTOR [FACTOR ...]
 
 positional arguments:
-  factor      block size by which to downsample image data
+  FACTOR      block size by which to downsample image data
 
 options:
   -h, --help  show this help message and exit
@@ -51,10 +51,10 @@ options:
 
 ```
 ❯ uv run stpreview input.asdf output.png to --help
-usage: stpreview INPUT OUTPUT to [-h] shape [shape ...]
+usage: stpreview INPUT OUTPUT to [-h] SHAPE [SHAPE ...]
 
 positional arguments:
-  shape       desired pixel resolution of output image
+  SHAPE       desired pixel resolution of output image
 
 options:
   -h, --help  show this help message and exit

--- a/README.md
+++ b/README.md
@@ -12,47 +12,52 @@ pip install stpreview
 
 ### Usage
 
+```
+❯ uv run stpreview --help
+usage: stpreview [-h] [--observatory {roman,jwst}] [--compass]
+                 INPUT OUTPUT {to,by} ...
+
+positional arguments:
+  INPUT                 path to ASDF file with 2D image data
+  OUTPUT                path to output image file
+  {to,by}
+    to                  downsample the given ASDF image by the given integer
+                        factor
+    by                  downsample the given ASDF image to the desired shape (the
+                        output image may be smaller than the desired shape, if no
+                        even factor exists)
+
+options:
+  -h, --help            show this help message and exit
+  --observatory {roman,jwst}
+                        (if omitted, will attempt to infer from file)
+  --compass             draw a north arrow on the image
+```
+
 #### `stpreview by`
 
 ```
-❯ stpreview by --help
-Usage: stpreview by [OPTIONS] INPUT OUTPUT FACTOR... [OBSERVATORY]
+❯ uv run stpreview input.asdf output.png by --help
+usage: stpreview INPUT OUTPUT by [-h] factor [factor ...]
 
-  downsample the given ASDF image by the given factor
+positional arguments:
+  factor      block size by which to downsample image data
 
-Arguments:
-  INPUT          path to ASDF file with 2D image data  [required]
-  OUTPUT         path to output image file  [required]
-  FACTOR...      block size by which to downsample image data  [required]
-  [OBSERVATORY]  observatory, one of ['roman', 'jwst']
-
-Options:
-  --compass / --no-compass  whether to draw a north arrow on the image
-                            [default: no-compass]
-  --help                    Show this message and exit.
+options:
+  -h, --help  show this help message and exit
 ```
 
 #### `stpreview to`
 
 ```
-❯ stpreview to --help
-Usage: stpreview to [OPTIONS] INPUT OUTPUT SHAPE... [OBSERVATORY]
+❯ uv run stpreview input.asdf output.png to --help
+usage: stpreview INPUT OUTPUT to [-h] shape [shape ...]
 
-  downsample the given ASDF image to the desired shape
+positional arguments:
+  shape       desired pixel resolution of output image
 
-  the output image may be smaller than the desired shape, if no even factor
-  exists
-
-Arguments:
-  INPUT          path to ASDF file with 2D image data  [required]
-  OUTPUT         path to output image file  [required]
-  SHAPE...       desired pixel resolution of output image  [required]
-  [OBSERVATORY]  observatory, one of ['roman', 'jwst']
-
-Options:
-  --compass / --no-compass  whether to draw a north arrow on the image
-                            [default: no-compass]
-  --help                    Show this message and exit.
+options:
+  -h, --help  show this help message and exit
 ```
 
 ### Examples
@@ -60,7 +65,7 @@ Options:
 ##### downsample a sample Roman image by a factor of 10, and add a compass rose
 
 ```shell
-stpreview by /grp/roman/TEST_DATA/23Q4_B11/aligntest/r0000501001001001001_01101_0001_WFI01_cal.asdf docs/images/by.png 10 10 --compass
+stpreview /grp/roman/TEST_DATA/23Q4_B11/aligntest/r0000501001001001001_01101_0001_WFI01_cal.asdf docs/images/by.png --compass by 10 10
 ```
 
 ![by](./docs/images/by.png)
@@ -68,7 +73,7 @@ stpreview by /grp/roman/TEST_DATA/23Q4_B11/aligntest/r0000501001001001001_01101_
 ##### downsample a sample Roman image to within 300x300 pixels
 
 ```shell
-stpreview to /grp/roman/TEST_DATA/23Q4_B11/aligntest/r0000501001001001001_01101_0001_WFI01_cal.asdf docs/images/to.png 300 300 roman
+stpreview /grp/roman/TEST_DATA/23Q4_B11/aligntest/r0000501001001001001_01101_0001_WFI01_cal.asdf docs/images/to.png to 300 300
 ```
 
 ![to](./docs/images/to.png)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ test = ["pytest", "roman_datamodels"]
 repository = "https://github.com/spacetelescope/stpreview.git"
 
 [project.scripts]
-stpreview = "stpreview.__main__:main"
+stpreview = "stpreview.__main__:command"
 
 [build-system]
 requires = ["setuptools >=60", "setuptools_scm[toml] >=3.4", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "matplotlib",
   "numpy",
   "scikit-image",
-  "typer",
 ]
 dynamic = ["version"]
 
@@ -42,10 +41,6 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.black]
-line-length = 88
-force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n    | \\.tox\n  )/\n)\n"
 
 [tool.ruff]
 line-length = 88

--- a/src/stpreview/__main__.py
+++ b/src/stpreview/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 from pathlib import Path
-from typing import Optional
 
 import asdf
 
@@ -13,70 +12,7 @@ from stpreview.downsample import (
 from stpreview.image import north_pole_angle, write_image
 
 
-def by(
-    input: Path,
-    output: Path,
-    factor: tuple[int, int],
-    observatory: Optional[str] = None,
-    compass: Optional[bool] = False,
-):
-    """
-    downsample the given ASDF image by the given factor
-    """
-
-    if observatory is None:
-        observatory = known_asdf_observatory(input)
-
-    data = downsample_asdf_by(input=input, factor=factor, observatory=observatory)
-
-    if compass:
-        with asdf.open(input) as file:
-            wcs = file[observatory]["meta"]["wcs"]
-        north_arrow_angle = north_pole_angle(wcs).degree - 90
-    else:
-        north_arrow_angle = None
-
-    write_image(
-        data,
-        output,
-        north_arrow_angle=north_arrow_angle,
-    )
-
-
-def to(
-    input: Path,
-    output: Path,
-    shape: tuple[int, int],
-    observatory: Optional[str] = None,
-    compass: Optional[bool] = False,
-):
-    """
-    downsample the given ASDF image to the desired shape
-
-    the output image may be smaller than the desired shape, if no even factor exists
-    """
-
-    if observatory is None:
-        observatory = known_asdf_observatory(input)
-
-    data = downsample_asdf_to(input=input, shape=shape, observatory=observatory)
-
-    if compass:
-        with asdf.open(input) as file:
-            wcs = file[observatory]["meta"]["wcs"]
-        north_arrow_angle = north_pole_angle(wcs).degree - 90
-    else:
-        north_arrow_angle = None
-
-    write_image(
-        data,
-        output,
-        shape=shape,
-        north_arrow_angle=north_arrow_angle,
-    )
-
-
-def main():
+def command():
     parser = argparse.ArgumentParser()
     parser.add_argument("INPUT", type=Path, help="path to ASDF file with 2D image data")
     parser.add_argument("OUTPUT", type=Path, help="path to output image file")
@@ -99,35 +35,52 @@ def main():
         "to", help="downsample the given ASDF image by the given integer factor"
     )
     to_parser.add_argument(
-        "shape",
+        "SHAPE",
         type=int,
         nargs="+",
         help="desired pixel shape of output image",
     )
-    to_parser.set_defaults(func=to)
 
     by_parser = subparsers.add_parser(
         "by",
         help="downsample the given ASDF image to the desired shape (the output image may be smaller than the desired shape, if no even factor exists)",
     )
     by_parser.add_argument(
-        "factor",
+        "FACTOR",
         type=int,
         nargs="+",
         help="integer factor by which to downsample input data",
     )
-    by_parser.set_defaults(func=by)
 
     arguments = parser.parse_args()
 
-    arguments.func(
-        arguments.INPUT,
+    observatory = arguments.observatory
+    if observatory is None:
+        observatory = known_asdf_observatory(arguments.INPUT)
+
+    if arguments.subcommand == "to":
+        data = downsample_asdf_to(
+            input=arguments.INPUT, shape=arguments.shape, observatory=observatory
+        )
+    elif arguments.subcommand == "by":
+        data = downsample_asdf_by(
+            input=arguments.INPUT, factor=arguments.factor, observatory=observatory
+        )
+
+    if arguments.compass:
+        with asdf.open(arguments.INPUT) as file:
+            wcs = file[observatory]["meta"]["wcs"]
+        north_arrow_angle = north_pole_angle(wcs).degree - 90
+    else:
+        north_arrow_angle = None
+
+    write_image(
+        data,
         arguments.OUTPUT,
-        arguments.shape if arguments.subcommand == "to" else arguments.factor,
-        arguments.observatory,
-        arguments.compass,
+        shape=arguments.shape if arguments.subcommand == "to" else None,
+        north_arrow_angle=north_arrow_angle,
     )
 
 
 if __name__ == "__main__":
-    main()
+    command()

--- a/src/stpreview/__main__.py
+++ b/src/stpreview/__main__.py
@@ -60,11 +60,11 @@ def command():
 
     if arguments.subcommand == "to":
         data = downsample_asdf_to(
-            input=arguments.INPUT, shape=arguments.shape, observatory=observatory
+            input=arguments.INPUT, shape=arguments.SHAPE, observatory=observatory
         )
     elif arguments.subcommand == "by":
         data = downsample_asdf_by(
-            input=arguments.INPUT, factor=arguments.factor, observatory=observatory
+            input=arguments.INPUT, factor=arguments.FACTOR, observatory=observatory
         )
 
     if arguments.compass:
@@ -77,7 +77,7 @@ def command():
     write_image(
         data,
         arguments.OUTPUT,
-        shape=arguments.shape if arguments.subcommand == "to" else None,
+        shape=arguments.SHAPE if arguments.subcommand == "to" else None,
         north_arrow_angle=north_arrow_angle,
     )
 

--- a/src/stpreview/downsample.py
+++ b/src/stpreview/downsample.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import asdf
 import numpy
@@ -8,7 +8,7 @@ from skimage.measure import block_reduce
 OBSERVATORIES = ["roman", "jwst"]
 
 
-def known_asdf_observatory(input: Path, known: list[str] = None) -> str:
+def known_asdf_observatory(input: Path, known: Optional[list[str]] = None) -> str:
     """
     find which observatory key exists in the given ASDF file
 
@@ -34,7 +34,7 @@ def downsample_asdf_by(
     input: Path,
     factor: Union[int, tuple[int, ...]],
     func=numpy.nanmean,
-    observatory: str = None,
+    observatory: Optional[str] = None,
 ) -> numpy.ndarray:
     """
     downsample an ASDF image by the specified factor
@@ -59,17 +59,19 @@ def downsample_asdf_by(
     else:
         block_size[-2] = factor[-2]
         block_size[-1] = factor[-1]
-    block_size = tuple(block_size)
 
     # for index, dimension in enumerate(data.shape):
     #     if dimension % block_size[index] != 0:
     #         raise RuntimeError(f"{by} is not an even factor of {data.shape}")
 
-    return block_reduce(data, block_size=block_size, func=func)
+    return block_reduce(data, block_size=tuple(block_size), func=func)
 
 
 def downsample_asdf_to(
-    input: Path, shape: tuple[int, int], func=numpy.nanmean, observatory: str = None
+    input: Path,
+    shape: tuple[int, int],
+    func=numpy.nanmean,
+    observatory: Optional[str] = None,
 ) -> numpy.ndarray:
     """
     attempt to downsample an ASDF image to (near) the specified resolution

--- a/tests/test_downsample_by.py
+++ b/tests/test_downsample_by.py
@@ -1,3 +1,5 @@
+import os
+
 import asdf
 import pytest
 from test_data import (
@@ -7,9 +9,7 @@ from test_data import (
     level2_image,
     level3_mosaic,
 )
-from typer.testing import CliRunner
 
-from stpreview.__main__ import app
 from stpreview.downsample import downsample_asdf_by
 
 OBSERVATORY = "roman"
@@ -46,9 +46,6 @@ def test_dummy_data(input, factor):
     assert result.shape == downsampled_shape
 
 
-runner = CliRunner()
-
-
 @pytest.mark.parametrize(
     "input",
     [
@@ -76,13 +73,10 @@ def test_command(input, factor, tmp_path):
 
     output = tmp_path / f"{input.stem}.png"
 
-    values = ["by", input, output]
-    if isinstance(factor, int):
-        values.append(factor)
-    else:
-        values.extend(factor)
-    status = runner.invoke(app, [str(value) for value in values])
-    assert status.exit_code == 0
+    exit_code = os.system(
+        f"stpreview --observatory roman {input} {output} by {factor if isinstance(factor, int) else ' '.join(factor)}"
+    )
+    assert exit_code == 0
 
 
 @pytest.mark.shareddata

--- a/tests/test_downsample_by.py
+++ b/tests/test_downsample_by.py
@@ -74,7 +74,7 @@ def test_command(input, factor, tmp_path):
     output = tmp_path / f"{input.stem}.png"
 
     exit_code = os.system(
-        f"stpreview --observatory roman {input} {output} by {factor if isinstance(factor, int) else ' '.join(factor)}"
+        f"stpreview --observatory roman {input} {output} by {' '.join(str(v) for v in factor)}"
     )
     assert exit_code == 0
 

--- a/tests/test_downsample_to.py
+++ b/tests/test_downsample_to.py
@@ -67,7 +67,7 @@ def test_command(input, shape, tmp_path):
     output = tmp_path / f"{input.stem}.png"
 
     exit_code = os.system(
-        f"stpreview --observatory roman {input} {output} to {shape if isinstance(shape, int) else ' '.join(shape)}"
+        f"stpreview --observatory roman {input} {output} to {' '.join(str(v) for v in shape)}"
     )
     assert exit_code == 0
 

--- a/tests/test_downsample_to.py
+++ b/tests/test_downsample_to.py
@@ -1,3 +1,5 @@
+import os
+
 import asdf
 import numpy
 import pytest
@@ -8,9 +10,7 @@ from test_data import (
     level2_image,
     level3_mosaic,
 )
-from typer.testing import CliRunner
 
-from stpreview.__main__ import app
 from stpreview.downsample import downsample_asdf_to
 
 OBSERVATORY = "roman"
@@ -42,9 +42,6 @@ def test_dummy_data(input, shape):
     assert numpy.all(numpy.array(result.shape) <= shape)
 
 
-runner = CliRunner()
-
-
 @pytest.mark.parametrize(
     "input",
     [
@@ -69,13 +66,10 @@ def test_command(input, shape, tmp_path):
 
     output = tmp_path / f"{input.stem}.png"
 
-    values = ["to", input, output]
-    if isinstance(shape, int):
-        values.append(shape)
-    else:
-        values.extend(shape)
-    status = runner.invoke(app, [str(value) for value in values])
-    assert status.exit_code == 0
+    exit_code = os.system(
+        f"stpreview --observatory roman {input} {output} to {shape if isinstance(shape, int) else ' '.join(shape)}"
+    )
+    assert exit_code == 0
 
 
 @pytest.mark.shareddata


### PR DESCRIPTION
This PR removes the dependence on Typer by using the builtin `argparse` instead. This change also reorders the order of CLI arguments so that the choice of subcommand `to` or `by` goes AFTER the input and output paths:

```diff
- stpreview by [--compass] INPUT OUTPUT FACTOR... [OBSERVATORY]
+ stpreview [--observatory {roman,jwst}] [--compass] INPUT OUTPUT by FACTOR...
```

```diff
- stpreview to [--compass] INPUT OUTPUT SHAPE... [OBSERVATORY]
+ stpreview [--observatory {roman,jwst}] [--compass] INPUT OUTPUT to SHAPE...
```

examples of how real usages of `stpreview` change:
```diff
- stpreview by input.asdf output.png 10 10 --compass
+ stpreview input.asdf output.png --compass by 10 10
- stpreview to input.asdf output.png 300 300 roman
+ stpreview input.asdf output.png to 300 300
```

This change is paired with a downstream PR in `romancal` updating usages of `stpreview`'s CLI there: https://github.com/spacetelescope/romancal/pull/1789