### PR TITLE
if error array is present, set nodata values to NaN

### DIFF
--- a/src/stpreview/downsample.py
+++ b/src/stpreview/downsample.py
@@ -52,6 +52,11 @@ def downsample_asdf_by(
     with asdf.open(input, memmap=True) as file:
         data = file[observatory]["data"]
 
+        # if error array is present, set nodata values to NaN
+        if "err" in file[observatory]:
+            err = file[observatory]["err"]
+            data = numpy.where(~numpy.isfinite(err) | (err <= 0), numpy.nan, data)
+
         block_size: list[int] = list(data.shape)
         if isinstance(factor, int):
             block_size[-2] = factor

--- a/src/stpreview/image.py
+++ b/src/stpreview/image.py
@@ -76,7 +76,8 @@ def write_image(
     """
 
     if normalization is None:
-        normalization = percentile_normalization(data, percentile=90)
+        if numpy.any(~numpy.isnan(data)):
+            normalization = percentile_normalization(data, percentile=90)
 
     if colormap is None:
         colormap = "afmhot"

--- a/tests/test_downsample_by.py
+++ b/tests/test_downsample_by.py
@@ -73,9 +73,9 @@ def test_command(input, factor, tmp_path):
 
     output = tmp_path / f"{input.stem}.png"
 
-    exit_code = os.system(
-        f"stpreview --observatory roman {input} {output} by {' '.join(str(v) for v in factor)}"
-    )
+    command = f"stpreview --observatory roman {input} {output} by {' '.join(str(v) for v in factor)}"
+    print(command)
+    exit_code = os.system(command)
     assert exit_code == 0
 
 

--- a/tests/test_downsample_to.py
+++ b/tests/test_downsample_to.py
@@ -66,9 +66,9 @@ def test_command(input, shape, tmp_path):
 
     output = tmp_path / f"{input.stem}.png"
 
-    exit_code = os.system(
-        f"stpreview --observatory roman {input} {output} to {' '.join(str(v) for v in shape)}"
-    )
+    command = f"stpreview --observatory roman {input} {output} to {' '.join(str(v) for v in shape)}"
+    print(command)
+    exit_code = os.system(command)
     assert exit_code == 0
 
 


### PR DESCRIPTION
Closes #6

```shell
stpreview /grp/roman/ddavis/roman/level3_products/r00001_p_v01001001001_r274dp63x31y80_f158_coadd_i2d.asdf test.png to 400 400
```
![test](https://github.com/user-attachments/assets/5e21ae59-7840-488f-b1ea-ffde01dc5415)

